### PR TITLE
問題6の実装

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -46,16 +46,12 @@ TEMPERATURE = 0.5
 # RAG参照用のデータソース系
 # ==========================================
 RAG_TOP_FOLDER_PATH = "./data"
-def _get_csv_loader():
-    """CSV用のローダー関数を遅延読み込みで取得"""
-    import utils
-    return utils.load_csv_as_department_chunks
 
 SUPPORTED_EXTENSIONS = {
     ".pdf": PyMuPDFLoader,
     ".docx": Docx2txtLoader,
-    ".csv": _get_csv_loader,  # 関数実行を遅延
-    ".txt": lambda path: TextLoader(path, encoding="utf-8")
+    ".csv": "csv_loader_selector",  # 文字列で関数名を指定（file_loadで処理）
+    ".txt": lambda path: TextLoader(path, encoding="utf-8"),
 }
 WEB_URL_LOAD_TARGETS = [
     "https://generative-ai.web-camp.io/"
@@ -67,7 +63,7 @@ WEB_URL_LOAD_TARGETS = [
 # ==========================================
 CHUNK_SIZE = 500
 CHUNK_OVERLAP = 50
-RETRIEVER_SEARCH_K = 8
+RETRIEVER_SEARCH_K = 5
 
 
 # ==========================================

--- a/constants.py
+++ b/constants.py
@@ -6,7 +6,6 @@
 # ライブラリの読み込み
 ############################################################
 from langchain_community.document_loaders import PyMuPDFLoader, Docx2txtLoader, TextLoader
-from langchain_community.document_loaders.csv_loader import CSVLoader
 
 
 ############################################################
@@ -47,10 +46,15 @@ TEMPERATURE = 0.5
 # RAG参照用のデータソース系
 # ==========================================
 RAG_TOP_FOLDER_PATH = "./data"
+def _get_csv_loader():
+    """CSV用のローダー関数を遅延読み込みで取得"""
+    import utils
+    return utils.load_csv_as_department_chunks
+
 SUPPORTED_EXTENSIONS = {
     ".pdf": PyMuPDFLoader,
     ".docx": Docx2txtLoader,
-    ".csv": lambda path: CSVLoader(path, encoding="utf-8"),
+    ".csv": _get_csv_loader,  # 関数実行を遅延
     ".txt": lambda path: TextLoader(path, encoding="utf-8")
 }
 WEB_URL_LOAD_TARGETS = [
@@ -63,7 +67,7 @@ WEB_URL_LOAD_TARGETS = [
 # ==========================================
 CHUNK_SIZE = 500
 CHUNK_OVERLAP = 50
-RETRIEVER_SEARCH_K = 5
+RETRIEVER_SEARCH_K = 8
 
 
 # ==========================================


### PR DESCRIPTION
### 概要
「人事部に所属している従業員情報を一覧化して」という問い合わせに対して、現在1人しか表示されない問題を解決し、4人以上（実際は9人）の情報が表示されるよう改善しました。

### 問題
- CSVファイルが各行ごとに個別ドキュメントとして分割されていた
- 関連ドキュメント最大値（5個）の制約により、最大5人の情報しか取得できなかった
- 検索精度が極めて低い状態だった

### 解決方法
CSV読み込み処理を部署別統合ローダーに変更し、検索しやすい構造化テキストで情報を整理しました。

### 変更内容

#### 1. \`utils.py\` - CSV統合ローダー関数の追加
- \`load_csv_as_department_chunks()\` 関数を新規追加
- 部署別にグループ化し、構造化されたテキスト形式で統合ドキュメントを生成
- 各従業員の詳細情報を整理された形式で出力

#### 2. \`constants.py\` - CSV用ローダー設定の更新
- \`_get_csv_loader()\` 関数で遅延読み込み対応
- \`SUPPORTED_EXTENSIONS\`でCSVファイルに新しいローダーを適用

#### 3. \`initialize.py\` - 初期化処理の修正
- \`file_load()\` 関数でCSVファイル用の特別処理を追加
- CSV統合ローダー関数を直接呼び出す処理に変更
- \`initialize_retriever()\` でCSVドキュメントの特別扱いを追加

### 改善効果
1. **統合ドキュメント化**: CSVの各行を個別ドキュメントではなく、部署別統合ドキュメントとして処理
2. **検索精度向上**: 「人事部に所属している従業員は9人います」のような明示的な情報を含む構造化テキスト
3. **制約回避**: 関連ドキュメント数の制約（最大5個）に影響されない統合アプローチ

### テスト方法
1. アプリを起動
2. 「社内問い合わせ」モードに設定
3. 「人事部に所属している従業員情報を一覧化して」と入力
4. 4人以上の従業員情報が表示されることを確認

### 技術的詳細
- 部署別にDataFrameをグループ化
- 各従業員の情報を構造化されたマークダウン形式で整理
- メタデータに部署名と従業員数を含める
- 既存のチャンク分割処理をCSVファイルではスキップ

### 実装後の改善結果
この改善により、社内問い合わせシステムの回答精度が大幅に向上し、実用的なレベルに達しました。

### レビューポイント
- CSV統合ローダーの実装が適切か
- 部署別グループ化のロジックに問題がないか
- 既存機能への影響がないか
- エラーハンドリングが適切か
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added specialized processing for employee roster CSV files, consolidating employee data by department into a single document for improved organization.

* **Improvements**
  * Enhanced CSV file handling by dynamically selecting appropriate loaders based on file type.
  * Adjusted document chunking logic to preserve employee roster CSVs without splitting.

* **Bug Fixes**
  * Corrected parameter name in model instantiation to ensure API compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->